### PR TITLE
Add thila-nginx-hc ArgoCD app and Helm values

### DIFF
--- a/applications/thila-nginx-hc.yaml
+++ b/applications/thila-nginx-hc.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: thila-nginx-hc
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: registry-1.docker.io/bitnamicharts
+      chart: nginx
+      targetRevision: 19.0.2
+      helm:
+        releaseName: nginx-hc
+        valueFiles:
+          - $values/manifests/thila-nginx-hc/values.yaml
+    - repoURL: https://github.com/slim-sandbox/argocd-demo.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    namespace: thila-ns
+    server: "https://kubernetes.default.svc"
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/thila-nginx-hc/values.yaml
+++ b/manifests/thila-nginx-hc/values.yaml
@@ -1,0 +1,8 @@
+replicaCount: 2
+
+service:
+  type: ClusterIP
+  port: 80
+
+image:
+  tag: 1.25.3-debian-11-r0


### PR DESCRIPTION
This PR adds an ArgoCD Application configuration to deploy Bitnami NGINX using Helm chart 19.0.2 with custom values to the thila-ns namespace.
